### PR TITLE
Refactor: Remove example usage from data_extraction.py and update tests

### DIFF
--- a/src/data_extraction.py
+++ b/src/data_extraction.py
@@ -14,9 +14,3 @@ def load_data(file_path):
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
         return None
-
-if __name__ == '__main__':
-    file_path = 'dataset.csv'
-    data = load_data(file_path)
-    if data is not None:
-        print(data.head())

--- a/tests/unit/test_data_extraction.py
+++ b/tests/unit/test_data_extraction.py
@@ -1,37 +1,37 @@
-import unittest
 import pandas as pd
-import os
+import pytest
 from src.data_extraction import load_data
 
-class TestDataExtraction(unittest.TestCase):
+def test_load_data_success():
+    """Test that the load_data function loads the data correctly."""
+    file_path = 'dataset.csv'
+    try:
+        df = load_data(file_path)
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+    except FileNotFoundError:
+        pytest.fail(f"The file {file_path} was not found.")
 
-    def test_load_data_success(self):
-        df = load_data('dataset.csv')
-        self.assertIsInstance(df, pd.DataFrame)
-        self.assertFalse(df.empty)  
-        self.assertIn('reviewId', df.columns)  
-        self.assertIn('userName', df.columns)  
-        self.assertIn('content', df.columns)   
-        self.assertIn('score', df.columns)     
 
-    def test_load_data_file_not_found(self):
-        with self.assertRaises(FileNotFoundError):
-            load_data('non_existent_file.csv')
+def test_load_data_file_not_found():
+    """Test that the load_data function raises FileNotFoundError for a missing file."""
+    file_path = 'non_existent_file.csv'
+    with pytest.raises(FileNotFoundError):
+        load_data(file_path)
 
-    def test_load_data_empty_file(self):
-        with open('empty_file.csv', 'w'):
-            pass  # Crée un fichier vide
 
-        df = load_data('empty_file.csv')
-        self.assertIsNone(df)
+def test_load_data_empty_file():
+    """Test that the load_data function handles empty files correctly."""
+    # Create an empty CSV file for testing
+    with open('empty_file.csv', 'w') as f:
+        pass  # Create an empty file
+    
+    df = load_data('empty_file.csv')
+    assert df is None
 
-        os.remove('empty_file.csv')
-
-    def tearDown(self):
-        if os.path.exists('empty_file.csv'):
-            os.remove('empty_file.csv')
-        if os.path.exists('test_data.csv'):
-            os.remove('test_data.csv')
-
-if __name__ == '__main__':
-    unittest.main()
+def test_load_data_expected_columns():
+    """Test that the loaded DataFrame has the expected columns."""
+    file_path = 'dataset.csv'
+    df = load_data(file_path)
+    expected_columns = ['reviewId', 'userName', 'userImage', 'content', 'score', 'thumbsUpCount', 'reviewCreatedVersion', 'at', 'replyContent', 'repliedAt', 'sortOrder', 'appId']  # Remplace avec les noms de tes colonnes
+    assert list(df.columns) == expected_columns


### PR DESCRIPTION
This pull request refactors the data extraction module to remove the example usage from `data_extraction.py`.

Changes:
- Removed the example usage block from `data_extraction.py` to ensure it only contains functions for data extraction.
- Updated `tests/unit/test_data_extraction.py` to reflect the removal of the example usage and to test the `load_data` function directly.

This change aligns with the project's requirement for separation of concerns and ensures that `data_extraction.py` only provides reusable data extraction functions.

@AdrielNathan  , please review and provide feedback.
