### PR TITLE
Refactor: Remove example usage from data_processing.py and update tests

### DIFF
--- a/src/data_processing.py
+++ b/src/data_processing.py
@@ -59,21 +59,3 @@ def split_data(df, test_size=0.2, random_state=42):
     """
     train_df, val_df = train_test_split(df, test_size=test_size, random_state=random_state)
     return train_df, val_df
-
-# Example usage (for testing purposes)
-if __name__ == '_main_':
-    data = {'content': ["This is a TeXt with  some   SPACES and 123! #@$"]}
-    example_df = pd.DataFrame(data)
-
-    cleaned_df = apply_cleaning(example_df)
-    tokenized_df = apply_tokenization(cleaned_df, tokenizer)
-    train_df, val_df = split_data(tokenized_df)
-
-    print("Cleaned DataFrame:")
-    print(cleaned_df.head())
-    print("\nTokenized DataFrame:")
-    print(tokenized_df.head())
-    print("\nTraining DataFrame:")
-    print(train_df.head())
-    print("\nValidation DataFrame:")
-    print(val_df.head())

--- a/tests/unit/test_data_processing.py
+++ b/tests/unit/test_data_processing.py
@@ -22,16 +22,18 @@ def test_apply_cleaning():
 
     pd.testing.assert_frame_equal(cleaned_df, expected_df)
 
-tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+@pytest.fixture
+def tokenizer():
+    return AutoTokenizer.from_pretrained("bert-base-uncased")
 
-def test_tokenize_text():
+def test_tokenize_text(tokenizer):
     # Test case 1: Basic tokenization
     text = "This is a test sentence."
     tokens = tokenize_text(text, tokenizer)
     assert tokens['input_ids'].shape == (1, 128)  # Check input_ids shape
     assert tokens['attention_mask'].shape == (1, 128)  # Check attention_mask shape
 
-def test_apply_tokenization():
+def test_apply_tokenization(tokenizer):
     # Test case 1: Basic DataFrame tokenization
     data = {'cleaned_content': ["This is a test sentence.", "Another sentence."]}
     example_df = pd.DataFrame(data)


### PR DESCRIPTION
This pull request refactors the data processing module to remove the example usage from data_processing.py.

Changes:
- Removed the example usage block from data_processing.py to ensure it only contains functions for data transformation.
- Updated test_data_processing.py to reflect the removal of the example usage and to test the functions individually.

This change aligns with the project's requirement for separation of concerns and ensures that data_processing.py only provides reusable data processing functions.

@OusmaneMomboMombo, please review and provide feedback.
