### PR TITLE
feat: add interactive terminal input to inference script

### DIFF
--- a/src/inference.py
+++ b/src/inference.py
@@ -46,11 +46,14 @@ if __name__ == '__main__':
     tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    texts = [
-        "This is a great product! I highly recommend it.",
-        "This is a terrible product! I do not recommend it."
-    ]
+    print("🧠 BERT Sentiment Analyzer")
+    print("Type a sentence to analyze the sentiment (or type 'exit' to quit)")
 
-    for text in texts:
-        sentiment = predict_sentiment(text, model, tokenizer, device)
-        print(f"Text: \"{text}\" → Sentiment: {sentiment}")
+    while True:
+        user_input = input("\n> Your sentence: ")
+        if user_input.lower() in ["exit", "quit", "q"]:
+            print("👋 Goodbye!")
+            break
+
+        sentiment = predict_sentiment(user_input, model, tokenizer, device)
+        print(f"👉 Sentiment: {sentiment.upper()}")


### PR DESCRIPTION
This pull request adds an interactive mode to inference.py, allowing users to input sentences directly from the terminal for sentiment prediction.

Changes : 
Added a terminal input loop in the __main__ block of inference.py

Allows users to enter custom text and receive predictions

Exit handled with standard commands (exit, quit, q)